### PR TITLE
Multiple windows installer issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ stages:
 env:
   global:
     - CACHE_NAME=${TRAVIS_JOB_NAME}
+    - COVERALLS_PARALLEL=true
 
 _commands_provider:
 
@@ -168,3 +169,5 @@ branches:
     - master
     - /\d*\.\d*\.\d*/
 
+notifications:
+  webhooks: https://coveralls.io/webhook

--- a/pyci/api/package/packager.py
+++ b/pyci/api/package/packager.py
@@ -315,7 +315,8 @@ class Packager(object):
              url=None,
              copyright_string=None,
              description=None,
-             license_path=None):
+             license_path=None,
+             program_files_dir=None):
 
         """
         Create a windows installer package.
@@ -347,6 +348,8 @@ class Packager(object):
             description (:str, optional): Package description. Defaults to the value specified in setup.py.
 
             license_path (:str, optional): Path to a license file. Defaults to the value specified in setup.py.
+
+            program_files_dir (:str, optional): Directory name inside Program Files where the app will be installed.
 
         Raises:
 
@@ -417,6 +420,8 @@ class Packager(object):
         url = url or self._url
         description = description or self._description
 
+        program_files_dir = program_files_dir or name
+
         config = {
             'name': name,
             'author': author,
@@ -425,7 +430,8 @@ class Packager(object):
             'license_path': license_path,
             'binary_path': binary_path,
             'description': description,
-            'installer_name': installer_name
+            'installer_name': installer_name,
+            'program_files_dir': program_files_dir
         }
 
         temp_dir = tempfile.mkdtemp()

--- a/pyci/api/package/packager.py
+++ b/pyci/api/package/packager.py
@@ -462,6 +462,13 @@ class Packager(object):
             makensis_path = os.path.join(temp_dir, 'nsis-3.04', 'makensis.exe')
             command = '{} -DVERSION={} {}'.format(makensis_path, version, installer_path)
 
+            # The installer expects the binary to be located in the working directory
+            # and be named {{ name }}.exe.
+            # See installer.nsi.jinja#L85
+            expected_binary_path = os.path.join(temp_dir, '{}.exe'.format(name))
+            self._debug('Copying binary to expected location: {}'.format(expected_binary_path))
+            shutil.copyfile(src=binary_path, dst=expected_binary_path)
+
             self._debug('Creating installer...')
             self._runner.run(command, cwd=temp_dir)
 

--- a/pyci/resources/windows_support/installer.nsi.jinja
+++ b/pyci/resources/windows_support/installer.nsi.jinja
@@ -11,6 +11,7 @@
 !define DESCRIPTION "{{ description }}"
 !define LICENSE_TXT "{{ license_path }}"
 !define INSTALLER_NAME "{{ installer_name }}.exe"
+!define PROGRAM_FILES_DIR "{{ program_files_dir }}"
 !define MAIN_APP_EXE "${APP_NAME}.exe"
 !define INSTALL_TYPE "SetShellVarContext all"
 !define REG_ROOT "HKLM"
@@ -39,7 +40,7 @@ OutFile "${INSTALLER_NAME}"
 BrandingText "${APP_NAME}"
 XPStyle on
 InstallDirRegKey "${REG_ROOT}" "${REG_APP_PATH}" ""
-InstallDir "$PROGRAMFILES\${APP_NAME}"
+InstallDir "$PROGRAMFILES\${PROGRAM_FILES_DIR}"
 
 ######################################################################
 

--- a/pyci/resources/windows_support/installer.nsi.jinja
+++ b/pyci/resources/windows_support/installer.nsi.jinja
@@ -82,7 +82,7 @@ Section -MainProgram
 ${INSTALL_TYPE}
 SetOverwrite ifnewer
 SetOutPath "$INSTDIR"
-File "{{ binary_path }}"
+File "${MAIN_APP_EXE}"
 
 Push $INSTDIR
 Call AddToPath

--- a/pyci/shell/commands/release.py
+++ b/pyci/shell/commands/release.py
@@ -97,7 +97,8 @@ def release(ctx,
             author,
             url,
             copyright_string,
-            license_path):
+            license_path,
+            program_files_dir):
 
     """
     Execute a complete release process.
@@ -179,7 +180,8 @@ def release(ctx,
                                              version=version,
                                              license_path=license_path,
                                              copyright_string=copyright_string,
-                                             url=url)
+                                             url=url,
+                                             program_files_dir=program_files_dir)
 
         log.sub()
 
@@ -223,7 +225,7 @@ def release(ctx,
         log.echo('PyPI: {}'.format(wheel_url))
 
 
-def _pack_installer(ctx, version, author, url, copyright_string, license_path, binary_path):
+def _pack_installer(ctx, version, author, url, copyright_string, license_path, binary_path, program_files_dir):
 
     if not utils.is_windows():
         # Currently installers are only supported for windows.
@@ -237,7 +239,8 @@ def _pack_installer(ctx, version, author, url, copyright_string, license_path, b
                                 author=author,
                                 url=url,
                                 copyright_string=copyright_string,
-                                license_path=license_path)
+                                license_path=license_path,
+                                program_files_dir=program_files_dir)
 
     return installer_path
 

--- a/pyci/shell/help.py
+++ b/pyci/shell/help.py
@@ -61,3 +61,5 @@ COPYRIGHT = 'Copyright string. Default to an empty value.'
 
 LICENSE = 'Path to a license file. This license will appear as part of the installation Wizard. Defaults ' \
           'to license value in setup.py (if exists)'
+
+PROGRAM_FILES_DIR = 'Directory name inside Program Files where the app will be installed'

--- a/pyci/shell/subcommands/pack.py
+++ b/pyci/shell/subcommands/pack.py
@@ -31,7 +31,8 @@ __nsis_common_options = [
     click.option('--author', required=False, help=pyci_help.AUTHOR),
     click.option('--url', required=False, help=pyci_help.URL),
     click.option('--copyright', 'copyright_string', required=False, help=pyci_help.COPYRIGHT),
-    click.option('--license', 'license_path', required=False, help=pyci_help.LICENSE)
+    click.option('--license', 'license_path', required=False, help=pyci_help.LICENSE),
+    click.option('--program-files-dir', 'program_files_dir', required=False, help=pyci_help.PROGRAM_FILES_DIR)
 ]
 
 
@@ -198,7 +199,7 @@ def wheel(ctx, universal, wheel_version):
               help='Path to write the created installer file.')
 @common_nsis_options()
 @handle_exceptions
-def nsis(ctx, binary_path, version, output, author, url, copyright_string, license_path):
+def nsis(ctx, binary_path, version, output, author, url, copyright_string, license_path, program_files_dir):
 
     """
     Create a windows executable installer.
@@ -223,7 +224,8 @@ def nsis(ctx, binary_path, version, output, author, url, copyright_string, licen
                                      author=author,
                                      url=url,
                                      copyright_string=copyright_string,
-                                     license_path=license_path)
+                                     license_path=license_path,
+                                     program_files_dir=program_files_dir)
         log.checkmark()
         log.echo('NSIS Installer created: {}'.format(package_path))
         return package_path

--- a/pyci/tests/shell/subcommands/test_pack.py
+++ b/pyci/tests/shell/subcommands/test_pack.py
@@ -220,7 +220,8 @@ def test_nsis_options(pack, mocker):
              '--author author '
              '--url url '
              '--copyright copyright '
-             '--license license')
+             '--license license '
+             '--program-files-dir pf')
 
     # noinspection PyUnresolvedReferences
     Packager.nsis.assert_called_once_with('binary-path',  # pylint: disable=no-member
@@ -229,7 +230,8 @@ def test_nsis_options(pack, mocker):
                                           author='author',
                                           url='url',
                                           copyright_string='copyright',
-                                          license_path='license')
+                                          license_path='license',
+                                          program_files_dir='pf')
 
 
 def test_nsis_no_setup_py(pack, repo_path, mocker):


### PR DESCRIPTION
This PR resolves issue #63 and #65 

## Issue #63

### What was the problem

Apparently, the name of the executable is determined by the base name of the `File` directive.
Not sure why I thought differently...

### What is the fix

So this means the `File` directive should be configured with the proper base name. i.e, instead of giving it `C:\Users\elip\py-ci-AMD64-Windows.exe`, we should pass `C:\Users\elip\py-ci.exe`.

This can be achieved by:

1. Asking the user to rename the file before creating the installer.
2. Just rename it ourselves before invoking the installer.

Bothering users is never good, so the fix includes creating a copy of the binary to a path that matches what we want.

## Issue #65 

### What was the problem

PyCI simply doesn't expose this, neither in the API nor in the CLI.

### What is the fix

#### API Changes

- Argument `program_files_dir` was added to `Package.nsis` method. This argument is optional and will default to the app name.

#### CLI Changes

- Option `--program-files-dir` was added to both `pack nsis` and `release` commands. This option is passed as the `program_files_dir` argument to the API stated above.